### PR TITLE
disable eslint max-len rule

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -57,12 +57,7 @@ rules:
   lodash/import-scope:
     - error
     - method
-  max-len:
-    - 1
-    - tabWidth: 2
-      ignoreComments: true
-      ignoreStrings: true
-      ignoreUrls: true
+  max-len: 0
   no-alert: 0
   no-await-in-loop: 1
   no-console: 0


### PR DESCRIPTION
Prettier manages line length
On occasion, this rule conflicts with what prettier does. In my experience this normally involves long strings.

<img width="407" alt="image" src="https://github.com/isw-kudos/eslint-config-node/assets/9063681/d9735c78-779e-42d3-9b73-6c07b7048bff">
